### PR TITLE
Add Flow check to Travis CI builds

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/lib/.*
 .*/node_modules/fbjs/lib/.*flow
+.*/node_modules/@briskhome/.*
 
 [include]
 ;.*/src/.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - yarn build
 script:
   # - yarn lint
+  - yarn flow
   - yarn test
 env:
   - CXX=g++-4.8

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "node_modules/.bin/babel src -d lib --copy-files --ignore node_modules",
     "build-cleanup": "rm -rf lib/*",
     "build-watch": "yarn build-cleanup && yarn babel-watch",
-    "flow": "flow",
+    "flow": "node_modules/.bin/flow",
     "lint": "eslint src --ext .js",
     "start": "node lib/core.js | bunyan -o short",
     "test": "node_modules/.bin/jest src --coverage",


### PR DESCRIPTION
This pull request finalises the Flow support in **Briskhome** development process by requiring a `yarn flow` check to pass before merging any pull request.