### PR TITLE
Add support for passing a custom name to logger

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -22,7 +22,7 @@ import { briskhomeAsciiLogo } from './utilities/constants';
     process.stderr.write(e.toString());
     process.exit(1);
   } finally {
-    const logger = app ? app.services.log() : () => null;
+    const logger = app ? app.services.log('core') : () => null;
     logger.info('Briskhome initialization successful');
   }
 })();

--- a/src/core.log/index.js
+++ b/src/core.log/index.js
@@ -4,7 +4,7 @@
  */
 
 import bunyan from 'bunyan';
-import { getCallee } from '../utilities/helpers';
+import { getCallee, normalizeName } from '../utilities/helpers';
 import type { CoreImports, CoreRegister } from '../types/coreTypes';
 
 export default (options: Object, imports: CoreImports, register: CoreRegister) => {
@@ -17,9 +17,9 @@ export default (options: Object, imports: CoreImports, register: CoreRegister) =
   });
 
   register(null, {
-    log: () => {
+    log: (name?: string) => {
       const child = log.child({
-        component: getCallee(),
+        component: name || normalizeName(getCallee()),
       });
       child.debug('Initialized logger instance for component');
       return child;

--- a/src/core.log/specs/index.spec.js
+++ b/src/core.log/specs/index.spec.js
@@ -1,6 +1,6 @@
 /* globals jest describe beforeAll beforeEach it expect */
 import bunyan from 'bunyan';
-import { getCallee } from '../../utilities/helpers';
+import { getCallee, normalizeName } from '../../utilities/helpers';
 import plugin from '../';
 
 jest.unmock('../');
@@ -35,7 +35,8 @@ describe('core.log', () => {
 
   beforeEach(() => {
     bunyan.createLogger.mockReturnValueOnce(log);
-    getCallee.mockReturnValueOnce('core.log');
+    normalizeName.mockReturnValueOnce('core.log');
+    getCallee.mockReturnValueOnce('@briskhome/core.log');
     log.child.mockReturnValueOnce(log);
   });
 

--- a/src/utilities/architect.js
+++ b/src/utilities/architect.js
@@ -8,7 +8,7 @@
 import fs from 'fs';
 import path from 'path';
 import events from 'events';
-import { normalizeName } from './plugins';
+import { normalizeName } from './helpers';
 
 
 // XXX: Consider replacing the following statement with `packagePathCache = new WeakMap();`

--- a/src/utilities/helpers.js
+++ b/src/utilities/helpers.js
@@ -17,3 +17,25 @@ export const getCallee = (depth?: number = 3): string => {
     return d.reduce((acc, s, i, a) => (s === 'lib' || s === 'node_modules' ? a[i + 1] : acc), '').split(':').shift();
   }
 };
+
+/**
+ * Strips plugin name from mandatory prefixes and namespaces.
+ * @param {String} name  Plugin name.
+ */
+export const normalizeName = (name: string): string => {
+  let normalizedName: string = name;
+
+  // if (name.indexOf('core.') >= 0) {
+  //   return name.substr(name.indexOf('core.') + 5);
+  // }
+
+  if (normalizedName.indexOf('/') >= 0) {
+    normalizedName = normalizedName.substr(normalizedName.indexOf('/') + 1);
+  }
+
+  if (normalizedName.indexOf('briskhome-') >= 0) {
+    normalizedName = normalizedName.substr(normalizedName.indexOf('briskhome-') + 10);
+  }
+
+  return normalizedName;
+};

--- a/src/utilities/plugins.js
+++ b/src/utilities/plugins.js
@@ -54,25 +54,3 @@ export const disablePlugin = (directory: string)
     }
     return false;
   }).length;
-
-/**
- * Strips plugin name from mandatory prefixes and namespaces.
- * @param {String} name  Plugin name.
- */
-export const normalizeName = (name: string): string => {
-  let normalizedName: string = name;
-
-  // if (name.indexOf('core.') >= 0) {
-  //   return name.substr(name.indexOf('core.') + 5);
-  // }
-
-  if (normalizedName.indexOf('/') >= 0) {
-    normalizedName = normalizedName.substr(normalizedName.indexOf('/') + 1);
-  }
-
-  if (normalizedName.indexOf('briskhome-') >= 0) {
-    normalizedName = normalizedName.substr(normalizedName.indexOf('briskhome-') + 10);
-  }
-
-  return normalizedName;
-};


### PR DESCRIPTION
This PR fixes an awkward bug that happened on every application start when `getCallee()` helper function could not determine the component name for `lib/core.js` file.