### PR TITLE
fix(core.db): invalid index in event schema

### DIFF
--- a/src/core.notifications/models/EventModel.js
+++ b/src/core.notifications/models/EventModel.js
@@ -26,7 +26,6 @@ export default ({ db }: CoreImports) => {
     {
       _id: {
         type: String,
-        unique: true,
       },
       name: {
         type: String,


### PR DESCRIPTION
This fixes an error that occurs when running Briskhome in CI environment.